### PR TITLE
feat: Add document formatting support

### DIFF
--- a/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
+++ b/src/main/java/net/prominic/groovyls/GroovyLanguageServer.java
@@ -92,6 +92,8 @@ public class GroovyLanguageServer implements LanguageServer, LanguageClientAware
         SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions();
         signatureHelpOptions.setTriggerCharacters(Arrays.asList("(", ","));
         serverCapabilities.setSignatureHelpProvider(signatureHelpOptions);
+        serverCapabilities.setDocumentFormattingProvider(true);
+        serverCapabilities.setDocumentRangeFormattingProvider(true);
 
         InitializeResult initializeResult = new InitializeResult(serverCapabilities);
         return CompletableFuture.completedFuture(initializeResult);

--- a/src/main/java/net/prominic/groovyls/GroovyServices.java
+++ b/src/main/java/net/prominic/groovyls/GroovyServices.java
@@ -60,6 +60,8 @@ import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Hover;
@@ -76,6 +78,7 @@ import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.TypeDefinitionParams;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
@@ -95,6 +98,7 @@ import net.prominic.groovyls.compiler.control.GroovyLSCompilationUnit;
 import net.prominic.groovyls.config.ICompilationUnitFactory;
 import net.prominic.groovyls.providers.CompletionProvider;
 import net.prominic.groovyls.providers.DefinitionProvider;
+import net.prominic.groovyls.providers.DocumentFormattingProvider;
 import net.prominic.groovyls.providers.DocumentSymbolProvider;
 import net.prominic.groovyls.providers.HoverProvider;
 import net.prominic.groovyls.providers.ReferenceProvider;
@@ -371,6 +375,24 @@ public class GroovyServices implements TextDocumentService, WorkspaceService, La
 
 		RenameProvider provider = new RenameProvider(astVisitor, fileContentsTracker);
 		return provider.provideRename(params);
+	}
+
+	@Override
+	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
+		URI uri = URI.create(params.getTextDocument().getUri());
+		recompileIfContextChanged(uri);
+
+		DocumentFormattingProvider provider = new DocumentFormattingProvider(fileContentsTracker, astVisitor);
+		return provider.provideFormatting(params.getTextDocument(), params.getOptions());
+	}
+
+	@Override
+	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
+		URI uri = URI.create(params.getTextDocument().getUri());
+		recompileIfContextChanged(uri);
+
+		DocumentFormattingProvider provider = new DocumentFormattingProvider(fileContentsTracker, astVisitor);
+		return provider.provideRangeFormatting(params.getTextDocument(), params.getRange(), params.getOptions());
 	}
 
 	// --- INTERNAL

--- a/src/main/java/net/prominic/groovyls/providers/DocumentFormattingProvider.java
+++ b/src/main/java/net/prominic/groovyls/providers/DocumentFormattingProvider.java
@@ -1,0 +1,270 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Prominic.NET, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// Author: Prominic.NET, Inc.
+// No warranty of merchantability or fitness of any kind.
+// Use this software at your own risk.
+////////////////////////////////////////////////////////////////////////////////
+package net.prominic.groovyls.providers;
+
+import java.io.StringWriter;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.codehaus.groovy.ast.ModuleNode;
+import org.codehaus.groovy.control.SourceUnit;
+import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+
+import net.prominic.groovyls.compiler.ast.ASTNodeVisitor;
+import net.prominic.groovyls.util.FileContentsTracker;
+
+public class DocumentFormattingProvider {
+    private FileContentsTracker fileContentsTracker;
+    private ASTNodeVisitor astVisitor;
+    
+    public DocumentFormattingProvider(FileContentsTracker fileContentsTracker, ASTNodeVisitor astVisitor) {
+        this.fileContentsTracker = fileContentsTracker;
+        this.astVisitor = astVisitor;
+    }
+    
+    public CompletableFuture<List<? extends TextEdit>> provideFormatting(
+            TextDocumentIdentifier textDocument, FormattingOptions options) {
+        URI uri = URI.create(textDocument.getUri());
+        String content = fileContentsTracker.getContents(uri);
+        
+        if (content == null || content.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+        
+        try {
+            String formattedContent = formatGroovyCode(content, options);
+            
+            if (formattedContent.equals(content)) {
+                return CompletableFuture.completedFuture(Collections.emptyList());
+            }
+            
+            // Calculate the range for the entire document
+            String[] lines = content.split("\n", -1);
+            int lastLine = Math.max(0, lines.length - 1);
+            int lastColumn = lines[lastLine].length();
+            
+            Range range = new Range(
+                new Position(0, 0),
+                new Position(lastLine, lastColumn)
+            );
+            
+            TextEdit edit = new TextEdit(range, formattedContent);
+            List<TextEdit> edits = new ArrayList<>();
+            edits.add(edit);
+            
+            return CompletableFuture.completedFuture(edits);
+        } catch (Exception e) {
+            // If formatting fails, return empty list
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+    }
+    
+    public CompletableFuture<List<? extends TextEdit>> provideRangeFormatting(
+            TextDocumentIdentifier textDocument, Range range, FormattingOptions options) {
+        URI uri = URI.create(textDocument.getUri());
+        String content = fileContentsTracker.getContents(uri);
+        
+        if (content == null || content.isEmpty()) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+        
+        try {
+            // Extract the content within the range
+            String[] lines = content.split("\n", -1);
+            StringBuilder rangeContent = new StringBuilder();
+            StringBuilder beforeRange = new StringBuilder();
+            StringBuilder afterRange = new StringBuilder();
+            
+            for (int i = 0; i < lines.length; i++) {
+                if (i < range.getStart().getLine()) {
+                    beforeRange.append(lines[i]);
+                    if (i < lines.length - 1) {
+                        beforeRange.append("\n");
+                    }
+                } else if (i > range.getEnd().getLine()) {
+                    afterRange.append("\n");
+                    afterRange.append(lines[i]);
+                } else if (i == range.getStart().getLine() && i == range.getEnd().getLine()) {
+                    // Range is within a single line
+                    beforeRange.append(lines[i].substring(0, range.getStart().getCharacter()));
+                    rangeContent.append(lines[i].substring(range.getStart().getCharacter(), range.getEnd().getCharacter()));
+                    afterRange.append(lines[i].substring(range.getEnd().getCharacter()));
+                } else if (i == range.getStart().getLine()) {
+                    beforeRange.append(lines[i].substring(0, range.getStart().getCharacter()));
+                    rangeContent.append(lines[i].substring(range.getStart().getCharacter()));
+                    if (i < range.getEnd().getLine()) {
+                        rangeContent.append("\n");
+                    }
+                } else if (i == range.getEnd().getLine()) {
+                    rangeContent.append(lines[i].substring(0, range.getEnd().getCharacter()));
+                    afterRange.append(lines[i].substring(range.getEnd().getCharacter()));
+                } else {
+                    rangeContent.append(lines[i]);
+                    if (i < range.getEnd().getLine()) {
+                        rangeContent.append("\n");
+                    }
+                }
+            }
+            
+            String formattedRangeContent = formatGroovyCode(rangeContent.toString(), options);
+            
+            if (formattedRangeContent.equals(rangeContent.toString())) {
+                return CompletableFuture.completedFuture(Collections.emptyList());
+            }
+            
+            TextEdit edit = new TextEdit(range, formattedRangeContent);
+            List<TextEdit> edits = new ArrayList<>();
+            edits.add(edit);
+            
+            return CompletableFuture.completedFuture(edits);
+        } catch (Exception e) {
+            return CompletableFuture.completedFuture(Collections.emptyList());
+        }
+    }
+    
+    private String formatGroovyCode(String code, FormattingOptions options) {
+        try {
+            GroovyCodeFormatter formatter = new GroovyCodeFormatter(options);
+            return formatter.format(code);
+        } catch (Exception e) {
+            // Return original code if formatting fails
+            return code;
+        }
+    }
+    
+    private static class GroovyCodeFormatter {
+        private FormattingOptions options;
+        private String indentString;
+        
+        public GroovyCodeFormatter(FormattingOptions options) {
+            this.options = options;
+            if (options.isInsertSpaces()) {
+                StringBuilder sb = new StringBuilder();
+                for (int i = 0; i < options.getTabSize(); i++) {
+                    sb.append(" ");
+                }
+                this.indentString = sb.toString();
+            } else {
+                this.indentString = "\t";
+            }
+        }
+        
+        public String format(String code) {
+            // First, split the code into statements/blocks
+            code = splitIntoLines(code);
+            
+            StringBuilder formatted = new StringBuilder();
+            String[] lines = code.split("\n", -1);
+            int indentLevel = 0;
+            boolean inMultilineComment = false;
+            
+            for (int lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+                String line = lines[lineIndex];
+                String trimmed = line.trim();
+                
+                // Handle multiline comments
+                if (trimmed.startsWith("/*")) {
+                    inMultilineComment = true;
+                }
+                
+                // Handle empty lines
+                if (trimmed.isEmpty()) {
+                    if (lineIndex < lines.length - 1) {
+                        formatted.append("\n");
+                    }
+                    continue;
+                }
+                
+                // Decrease indent for closing braces
+                if (!inMultilineComment && (trimmed.startsWith("}") || trimmed.startsWith("]") || trimmed.startsWith(")"))) {
+                    indentLevel = Math.max(0, indentLevel - 1);
+                }
+                
+                // Add indentation
+                for (int i = 0; i < indentLevel; i++) {
+                    formatted.append(indentString);
+                }
+                
+                // Format the line content
+                String formattedLine = formatLine(trimmed);
+                formatted.append(formattedLine);
+                
+                // Add newline except for last line if original didn't have one
+                if (lineIndex < lines.length - 1 || code.endsWith("\n")) {
+                    formatted.append("\n");
+                }
+                
+                // Increase indent for opening braces
+                if (!inMultilineComment && (formattedLine.endsWith("{") || formattedLine.endsWith("[") || formattedLine.endsWith("("))) {
+                    indentLevel++;
+                }
+                
+                // Handle multiline comments
+                if (trimmed.endsWith("*/")) {
+                    inMultilineComment = false;
+                }
+            }
+            
+            return formatted.toString();
+        }
+        
+        private String splitIntoLines(String code) {
+            // Split single-line code blocks into multiple lines
+            code = code.replaceAll("\\{", "{\n");
+            code = code.replaceAll("\\}", "\n}");
+            code = code.replaceAll(";", ";\n");
+            
+            // Clean up multiple newlines
+            code = code.replaceAll("\n+", "\n");
+            code = code.trim();
+            
+            return code;
+        }
+        
+        private String formatLine(String line) {
+            // Add spaces around braces, parentheses, etc.
+            line = line.replaceAll("\\s*\\{\\s*", " {");
+            line = line.replaceAll("\\s*\\}\\s*", "}");
+            line = line.replaceAll("\\s*\\(\\s*", "(");
+            line = line.replaceAll("\\s*\\)\\s*", ")");
+            line = line.replaceAll("\\s*=\\s*", " = ");
+            
+            // Handle method definitions
+            line = line.replaceAll("\\)\\{", ") {");
+            
+            // Handle class definitions
+            if (line.startsWith("class")) {
+                line = line.replaceAll("class\\s+", "class ");
+            }
+            
+            // Clean up multiple spaces
+            line = line.replaceAll("\\s+", " ");
+            
+            return line.trim();
+        }
+    }
+}

--- a/src/test/java/net/prominic/groovyls/GroovyServicesFormattingTests.java
+++ b/src/test/java/net/prominic/groovyls/GroovyServicesFormattingTests.java
@@ -1,0 +1,222 @@
+////////////////////////////////////////////////////////////////////////////////
+// Copyright 2022 Prominic.NET, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+//
+// Author: Prominic.NET, Inc.
+// No warranty of merchantability or fitness of any kind.
+// Use this software at your own risk.
+////////////////////////////////////////////////////////////////////////////////
+package net.prominic.groovyls;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import net.prominic.groovyls.config.CompilationUnitFactory;
+
+public class GroovyServicesFormattingTests {
+    private static final String LANGUAGE_GROOVY = "groovy";
+    
+    private GroovyServices services;
+    private Path workspaceRoot;
+    
+    @BeforeEach
+    void setup() {
+        workspaceRoot = Paths.get(System.getProperty("user.dir")).resolve("src/test/java/net/prominic/groovyls");
+        services = new GroovyServices(new CompilationUnitFactory());
+        services.connect(new LanguageClient() {
+            @Override
+            public void logMessage(org.eclipse.lsp4j.MessageParams params) {
+            }
+            
+            @Override
+            public void publishDiagnostics(org.eclipse.lsp4j.PublishDiagnosticsParams params) {
+            }
+            
+            @Override
+            public void showMessage(org.eclipse.lsp4j.MessageParams params) {
+            }
+            
+            @Override
+            public CompletableFuture<org.eclipse.lsp4j.MessageActionItem> showMessageRequest(
+                    org.eclipse.lsp4j.ShowMessageRequestParams params) {
+                return null;
+            }
+            
+            @Override
+            public void telemetryEvent(Object params) {
+            }
+        });
+        services.setWorkspaceRoot(workspaceRoot);
+    }
+    
+    @AfterEach
+    void tearDown() {
+        services = null;
+        workspaceRoot = null;
+    }
+    
+    @Test
+    void testFormatDocument_SimpleClass() throws Exception {
+        String uri = workspaceRoot.resolve("TestFormatting.groovy").toUri().toString();
+        String unformattedContent = "class   TestClass{def    method(){return   42}}";
+        
+        // Open document with unformatted content
+        services.didOpen(new org.eclipse.lsp4j.DidOpenTextDocumentParams(
+            new org.eclipse.lsp4j.TextDocumentItem(uri, LANGUAGE_GROOVY, 1, unformattedContent)
+        ));
+        
+        DocumentFormattingParams params = new DocumentFormattingParams();
+        params.setTextDocument(new TextDocumentIdentifier(uri));
+        
+        FormattingOptions options = new FormattingOptions();
+        options.setTabSize(4);
+        options.setInsertSpaces(true);
+        params.setOptions(options);
+        
+        CompletableFuture<List<? extends TextEdit>> future = services.formatting(params);
+        List<? extends TextEdit> edits = future.get();
+        
+        assertNotNull(edits);
+        assertEquals(1, edits.size());
+        
+        TextEdit edit = edits.get(0);
+        assertEquals(new Position(0, 0), edit.getRange().getStart());
+        assertEquals(new Position(0, 47), edit.getRange().getEnd());
+        
+        String expectedFormatted = "class TestClass {\n    def method() {\n        return 42\n    }\n}";
+        assertEquals(expectedFormatted, edit.getNewText());
+    }
+    
+    @Test
+    void testFormatDocument_WithImports() throws Exception {
+        String uri = workspaceRoot.resolve("TestFormattingImports.groovy").toUri().toString();
+        String unformattedContent = "import java.util.List\nimport java.util.Map\n\n\nclass TestClass{List<String> items=[]}";
+        
+        services.didOpen(new org.eclipse.lsp4j.DidOpenTextDocumentParams(
+            new org.eclipse.lsp4j.TextDocumentItem(uri, LANGUAGE_GROOVY, 1, unformattedContent)
+        ));
+        
+        DocumentFormattingParams params = new DocumentFormattingParams();
+        params.setTextDocument(new TextDocumentIdentifier(uri));
+        
+        FormattingOptions options = new FormattingOptions();
+        options.setTabSize(4);
+        options.setInsertSpaces(true);
+        params.setOptions(options);
+        
+        CompletableFuture<List<? extends TextEdit>> future = services.formatting(params);
+        List<? extends TextEdit> edits = future.get();
+        
+        assertNotNull(edits);
+        assertTrue(edits.size() > 0);
+    }
+    
+    @Test
+    void testFormatDocumentRange() throws Exception {
+        String uri = workspaceRoot.resolve("TestRangeFormatting.groovy").toUri().toString();
+        String content = "class TestClass {\n    def method1(){return 1}\n    def method2(){return 2}\n}";
+        
+        services.didOpen(new org.eclipse.lsp4j.DidOpenTextDocumentParams(
+            new org.eclipse.lsp4j.TextDocumentItem(uri, LANGUAGE_GROOVY, 1, content)
+        ));
+        
+        DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
+        params.setTextDocument(new TextDocumentIdentifier(uri));
+        params.setRange(new Range(new Position(1, 0), new Position(1, 27))); // Only format method1
+        
+        FormattingOptions options = new FormattingOptions();
+        options.setTabSize(4);
+        options.setInsertSpaces(true);
+        params.setOptions(options);
+        
+        CompletableFuture<List<? extends TextEdit>> future = services.rangeFormatting(params);
+        List<? extends TextEdit> edits = future.get();
+        
+        assertNotNull(edits);
+        assertTrue(edits.size() > 0);
+        
+        // Verify that only the specified range is formatted
+        for (TextEdit edit : edits) {
+            assertTrue(edit.getRange().getStart().getLine() >= 1);
+            assertTrue(edit.getRange().getEnd().getLine() <= 1);
+        }
+    }
+    
+    @Test
+    void testFormatDocument_WithTabsOption() throws Exception {
+        String uri = workspaceRoot.resolve("TestFormattingTabs.groovy").toUri().toString();
+        String unformattedContent = "class TestClass{def method(){return 42}}";
+        
+        services.didOpen(new org.eclipse.lsp4j.DidOpenTextDocumentParams(
+            new org.eclipse.lsp4j.TextDocumentItem(uri, LANGUAGE_GROOVY, 1, unformattedContent)
+        ));
+        
+        DocumentFormattingParams params = new DocumentFormattingParams();
+        params.setTextDocument(new TextDocumentIdentifier(uri));
+        
+        FormattingOptions options = new FormattingOptions();
+        options.setTabSize(4);
+        options.setInsertSpaces(false); // Use tabs instead of spaces
+        params.setOptions(options);
+        
+        CompletableFuture<List<? extends TextEdit>> future = services.formatting(params);
+        List<? extends TextEdit> edits = future.get();
+        
+        assertNotNull(edits);
+        assertTrue(edits.size() > 0);
+        
+        TextEdit edit = edits.get(0);
+        assertTrue(edit.getNewText().contains("\t")); // Should contain tabs
+    }
+    
+    @Test
+    void testFormatDocument_EmptyDocument() throws Exception {
+        String uri = workspaceRoot.resolve("TestFormattingEmpty.groovy").toUri().toString();
+        String content = "";
+        
+        services.didOpen(new org.eclipse.lsp4j.DidOpenTextDocumentParams(
+            new org.eclipse.lsp4j.TextDocumentItem(uri, LANGUAGE_GROOVY, 1, content)
+        ));
+        
+        DocumentFormattingParams params = new DocumentFormattingParams();
+        params.setTextDocument(new TextDocumentIdentifier(uri));
+        
+        FormattingOptions options = new FormattingOptions();
+        options.setTabSize(4);
+        options.setInsertSpaces(true);
+        params.setOptions(options);
+        
+        CompletableFuture<List<? extends TextEdit>> future = services.formatting(params);
+        List<? extends TextEdit> edits = future.get();
+        
+        assertTrue(edits == null || edits.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- ドキュメント整形機能を実装し、Groovyコードの自動整形を可能にしました
- Language Server Protocolの`textDocument/formatting`と`textDocument/rangeFormatting`をサポート

## Changes
- `DocumentFormattingProvider`クラスを新規作成
  - ドキュメント全体の整形機能
  - 選択範囲の整形機能
  - タブ/スペースの設定に対応
- `GroovyServices`に整形メソッドを追加
- `GroovyLanguageServer`でフォーマット機能を有効化
- 包括的なテストスイートを追加（5つのテストケース）

## Test plan
- [x] 基本的なクラスの整形テスト
- [x] インポート文を含むコードの整形テスト
- [x] 範囲指定での整形テスト
- [x] タブ/スペース設定のテスト
- [x] 空ドキュメントの処理テスト
- [x] 既存のテストに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)